### PR TITLE
feat(force_lang_env): allow (optionally) forcing LANG env. encoding

### DIFF
--- a/PyYapf.py
+++ b/PyYapf.py
@@ -164,6 +164,11 @@ class YapfCommand(sublime_plugin.TextCommand):
 
         print('Using encoding of %r' % self.encoding)
 
+        # force set ENV var to avoid issue google/yapf#49
+        if settings.get('force_lang_env', False):
+            previous_env_var = os.environ.get('LANG')
+            os.environ['LANG'] = self.encoding
+
         self.debug = settings.get('debug', False)
 
         # there is always at least one region
@@ -222,4 +227,8 @@ class YapfCommand(sublime_plugin.TextCommand):
         print('restoring cursor to ', region, repr(region))
         self.view.show_at_center(region)
 
+        if settings.get('force_lang_env', False):
+            if previous_env_var:
+                # restore previous LANG env. variable
+                os.environ['LANG'] = previous_env_var
         print('PyYapf Completed')


### PR DESCRIPTION
otherwise yapf may fail regardless of module "coding"; as seen in
issue google/yapf#49