### PR TITLE
Style handling

### DIFF
--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,0 +1,8 @@
+[
+    {
+        "keys": [
+            "ctrl+alt+f"
+        ],
+        "command": "yapf"
+    }
+]

--- a/PyYapf.py
+++ b/PyYapf.py
@@ -234,6 +234,10 @@ class YapfCommand(sublime_plugin.TextCommand):
             else:
                 style_filename = None
 
+            # use directory of current file so that custom styles are found properly
+            fname = self.view.file_name()
+            cwd = os.path.dirname(fname) if fname else None
+
             # specify encoding in environment
             env = os.environ.copy()
             env['LANG'] = self.encoding
@@ -247,13 +251,14 @@ class YapfCommand(sublime_plugin.TextCommand):
                 startupinfo = None
 
             # run yapf
-            print('Running {0}'.format(args))
+            print('Running {0} in {1}'.format(args, cwd))
             if self.debug:
                 print('Environment: {0}'.format(env))
             popen = subprocess.Popen(args,
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE,
                                      stdin=subprocess.PIPE,
+                                     cwd=cwd,
                                      env=env,
                                      startupinfo=startupinfo)
             output, output_err = popen.communicate(encoded_selection)

--- a/PyYapf.py
+++ b/PyYapf.py
@@ -169,13 +169,11 @@ class YapfCommand(sublime_plugin.TextCommand):
         return unindented
 
     def replace_selection(self, edit, selection, output):
-        reindented = []
         indent = self.indent.decode(self.encoding)
-        line_endings = self.view.line_endings()
-        for line in output.splitlines(keepends=True):
-            reindented.append(indent + line)
+        reindented = []
+        for line in output.splitlines():
+            reindented.append(indent + line + '\n')
         self.view.replace(edit, selection, ''.join(reindented))
-        self.view.set_line_endings(line_endings)
 
     def run(self, edit):
         """

--- a/PyYapf.py
+++ b/PyYapf.py
@@ -197,16 +197,16 @@ class YapfCommand(sublime_plugin.TextCommand):
 
         if self.encoding == "Undefined":
             print('Encoding is not specified.')
-            self.encoding = settings.get('default_encoding', 'UTF-8')
+            self.encoding = settings.get('default_encoding')
 
         print('Using encoding of %r' % self.encoding)
 
-        self.debug = settings.get('debug', False)
+        self.debug = settings.get('debug')
 
         # there is always at least one region
         for region in self.view.sel():
             if region.empty():
-                if settings.get("use_entire_file_if_no_selection", True):
+                if settings.get("use_entire_file_if_no_selection"):
                     selection = sublime.Region(0, self.view.size())
                 else:
                     sublime.error_message('A selection is required')
@@ -229,8 +229,8 @@ class YapfCommand(sublime_plugin.TextCommand):
 
                     # override style?
                     if settings.has('config'):
-                        style_filename = save_style_to_tempfile(settings.get(
-                            "config", {}))
+                        custom_style = settings.get("config")
+                        style_filename = save_style_to_tempfile(custom_style)
                         args += ["--style={0}".format(style_filename)]
 
                         if self.debug:

--- a/PyYapf.py
+++ b/PyYapf.py
@@ -115,8 +115,8 @@ class YapfCommand(sublime_plugin.TextCommand):
         """
         err, msg, context_dict = failure_parser(in_failure, self.encoding)
 
-        sublime.error_message(
-            "{0}\n{1}\n\n{2}".format(err, msg, repr(context_dict)))
+        sublime.error_message("{0}\n{1}\n\n{2}".format(err, msg, repr(
+            context_dict)))
 
         if 'context' in context_dict:
             #"('', (46,44))"

--- a/PyYapf.sublime-settings
+++ b/PyYapf.sublime-settings
@@ -2,23 +2,63 @@
       // full path and command to run yapf
       "yapf_command": "/usr/local/bin/yapf",
 
+      // reformat entire file if no text is selected
       "use_entire_file_if_no_selection": true,
 
       // add extra output to the console for debugging pyyapf/yapf behavior
       "debug": false,
 
       // if no encoding is specified use this.  utf-8 is a good choice,
-      // ascii is (much) more restrictive.  Any of these should work:
+      // ascii is (much) more restrictive.  any of these should work:
       // https://docs.python.org/2/library/codecs.html#standard-encodings
       "default_encoding": "UTF-8",
 
       // yapf style options
       "config": {
+            // Determines which of the predefined styles this custom style is based on.
+            "based_on_style": "pep8",
+
             // Align closing bracket with visual indentation.
             "ALIGN_CLOSING_BRACKET_WITH_VISUAL_INDENT": true,
 
+            // Insert a blank line before a 'def' or 'class' immediately
+            // nested within another 'def' or 'class'.
+            //
+            // For example:
+            //
+            // class Foo:
+            //                    # <------ this blank line
+            //   def method():
+            //     ...
+            //
+            "BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF": false,
+
             // The column limit.
             "COLUMN_LIMIT": 79,
+
+            // Indent width for line continuations.
+            "CONTINUATION_INDENT_WIDTH": 4,
+
+            // Put closing brackets on a separate line, dedented, if the
+            // bracketed expression can't fit in a single line. Applies to
+            // all kinds of brackets, including function definitions and calls.
+            //
+            // For example:
+            //
+            // config = {
+            //     'key1': 'value1',
+            //     'key2': 'value2',
+            // }        # <--- this bracket is dedented and on a separate line
+            //
+            // time_series = self.remote_client.query_entity_counters(
+            //   entity='dev3246.region1',
+            //   key='dns.query_latency_tcp',
+            //   transform=Transformation.AVERAGE(window=timedelta(seconds=60)),
+            //   start_ts=now()-timedelta(days=3),
+            //   end_ts=now(),
+            // )        # <--- this bracket is dedented and on a separate line
+
+            "DEDENT_CLOSING_BRACKETS": false,
 
             // The regex for an i18n comment. The presence of this comment stops
             // reformatting of that line, because the comments are required to be
@@ -30,23 +70,23 @@
             // away from the i18n comment.
             "I18N_FUNCTION_CALL": "",
 
-            // The number of columns to use for indentation.
-            "INDENT_WIDTH": 4,
-
-            // Indent width for line continuations.
-            "CONTINUATION_INDENT_WIDTH": 4,
-
-            // Insert a blank line before a 'def' or 'class' immediately nested within
-            //another 'def' or 'class'.
+            // Indent the dictionary value if it cannot fit on the same line as the dictionary key.
             //
             // For example:
             //
-            // class Foo:
-            //                    # <------ this blank line
-            //   def method():
-            //     ...
-            //
-            "BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF": false,
+            // config = {
+            //     'key1':
+            //         'value1',
+            //     'key2': value1 +
+            //             value2,
+            // }
+            "INDENT_DICTIONARY_VALUE": false,
+
+            // The number of columns to use for indentation.
+            "INDENT_WIDTH": 4,
+
+            // Join short lines into one line. E.g., single line if statements.
+            "JOIN_MULTIPLE_LINES": true,
 
             // Insert a space between the ending comma and closing bracket of a list,
             // etc.
@@ -55,6 +95,9 @@
             // The number of spaces required before a trailing comment.
             "SPACES_BEFORE_COMMENT": 2,
 
+            // Set to True to prefer splitting before &, | or ^ rather than after.
+            "SPLIT_BEFORE_BITWISE_OPERATOR": true,
+
             // Set to True to prefer splitting before 'and' or 'or' rather than
             // after.
             "SPLIT_BEFORE_LOGICAL_OPERATOR": false,
@@ -62,26 +105,37 @@
             // Split named assignments onto individual lines.
             "SPLIT_BEFORE_NAMED_ASSIGNS": true,
 
-            // The penalty for splitting the line after a unary operator.
-            "SPLIT_PENALTY_AFTER_UNARY_OPERATOR": 100,
-
-            // The penalty for characters over the column limit.
-            "SPLIT_PENALTY_EXCESS_CHARACTER": 200,
-
-            // The penalty of splitting the line around the 'and' and 'or' operators.
-            "SPLIT_PENALTY_LOGICAL_OPERATOR": 30,
-
-            // The penalty for not matching the splitting decision for the matching
-            // bracket tokens. For instance, if there is a newline after the opening
-            // bracket, we would tend to expect one before the closing bracket, and
-            // vice versa.
-            //"SPLIT_PENALTY_MATCHING_BRACKET": 50,
-
             // The penalty for splitting right after the opening bracket.
             "SPLIT_PENALTY_AFTER_OPENING_BRACKET": 30,
 
+            // The penalty for splitting the line after a unary operator.
+            "SPLIT_PENALTY_AFTER_UNARY_OPERATOR": 10000,
+
+            // The penalty of splitting the line around the &, |, and ^ operators.
+            "SPLIT_PENALTY_BITWISE_OPERATOR": 300,
+
+            // The penalty for characters over the column limit.
+            "SPLIT_PENALTY_EXCESS_CHARACTER": 2500,
+
             // The penalty incurred by adding a line split to the unwrapped line. The
             // more line splits added the higher the penalty.
-            "SPLIT_PENALTY_FOR_ADDED_LINE_SPLIT": 30
-      }
+            "SPLIT_PENALTY_FOR_ADDED_LINE_SPLIT": 30,
+
+            // The penalty of splitting a list of import as names.
+            //
+            // For example:
+            //
+            //   from a_very_long_or_indented_module_name_yada_yad import (long_argument_1,
+            //                                                             long_argument_2,
+            //                                                             long_argument_3)
+            //
+            // would reformat to something like:
+            //
+            // from a_very_long_or_indented_module_name_yada_yad import (
+            //     long_argument_1, long_argument_2, long_argument_3)
+            "SPLIT_PENALTY_IMPORT_NAMES": 0,
+
+            // The penalty of splitting the line around the 'and' and 'or' operators.
+            "SPLIT_PENALTY_LOGICAL_OPERATOR": 300,
+      },
 }

--- a/PyYapf.sublime-settings
+++ b/PyYapf.sublime-settings
@@ -12,7 +12,12 @@
 
       // custom yapf style options
       //
-      // if commented out then yapf's default style will be used (PEP8)
+      // if commented out then yapf will search for the formatting style in the following manner:
+      // 1. in the [style] section of a .style.yapf file in either the current directory or one of its parent directories.
+      // 2. in the [yapf] section of a setup.cfg file in either the current directory or one of its parent directories.
+      // 3. in the ~/.config/yapf/style file in your home directory.
+      // if none of those files are found, the default style is used (PEP8).
+      //
       /*
       "config": {
             // Determines which of the predefined styles this custom style is based on.

--- a/PyYapf.sublime-settings
+++ b/PyYapf.sublime-settings
@@ -5,20 +5,19 @@
       // reformat entire file if no text is selected
       "use_entire_file_if_no_selection": true,
 
-      // add extra output to the console for debugging pyyapf/yapf behavior
-      "debug": false,
-
       // if no encoding is specified use this.  utf-8 is a good choice,
       // ascii is (much) more restrictive.  any of these should work:
       // https://docs.python.org/2/library/codecs.html#standard-encodings
       "default_encoding": "UTF-8",
 
-      // yapf style options
+      // custom yapf style options
+      //
+      // if commented out then yapf's default style will be used (PEP8)
+      /*
       "config": {
             // Determines which of the predefined styles this custom style is based on.
             "based_on_style": "pep8",
 
-/*
             // Align closing bracket with visual indentation.
             "ALIGN_CLOSING_BRACKET_WITH_VISUAL_INDENT": true,
 
@@ -138,6 +137,9 @@
 
             // The penalty of splitting the line around the 'and' and 'or' operators.
             "SPLIT_PENALTY_LOGICAL_OPERATOR": 300,
-*/
       },
+      */
+
+      // add extra output to the console for debugging pyyapf/yapf behavior
+      "debug": false,
 }

--- a/PyYapf.sublime-settings
+++ b/PyYapf.sublime-settings
@@ -18,6 +18,7 @@
             // Determines which of the predefined styles this custom style is based on.
             "based_on_style": "pep8",
 
+/*
             // Align closing bracket with visual indentation.
             "ALIGN_CLOSING_BRACKET_WITH_VISUAL_INDENT": true,
 
@@ -137,5 +138,6 @@
 
             // The penalty of splitting the line around the 'and' and 'or' operators.
             "SPLIT_PENALTY_LOGICAL_OPERATOR": 300,
+*/
       },
 }


### PR DESCRIPTION
Use yapf's default style handling (as explained in `yapf --help`). This requires an implementation change, namely that the source snippet to be formatted is passed on stdin rather than via a temporary file (which is anyways good practice) with the current directory set to the directory of the source file.

Further changes:
- Updated the settings file with the latest yapf defaults (c555eae6b90d64d87bfc2c70ad98738aa7a5265a).
- Fixed Windows support (hide console window in 033cd87af31d1f8e9febbec6773280ca0eddc0a6, newline handling in 72271cf95993a1b9f87480aa0a7355aa7d999e7b).