### PR TITLE
Check common locations for yapf and persist to settings

### DIFF
--- a/PyYapf.py
+++ b/PyYapf.py
@@ -17,6 +17,11 @@ import textwrap
 import sublime
 import sublime_plugin
 
+try:
+    from shutil import which
+except ImportError:
+    from backports.shutil_which import which
+
 # make sure we don't choke on unicode when we reformat ourselves
 u"我爱蟒蛇"
 
@@ -187,24 +192,18 @@ class Yapf:
             cmd,
             sublime.active_window().extract_variables())
 
+        save_settings = not cmd
+
         if not cmd:
-            # some common possibilities
-            for common_location in [
-                    "/usr/local/bin/yapf",  # most common
-                    "/usr/bin/yapf3",  # Ubnt 18.04
-                    "~/Library/Python/2.7/bin/yapf",  # OSx installed with --user
-                    "C:\\Python\\Scripts\\yapf.exe",  # Ugg.
-                    "~/AppData/Local/Programs/Python/Python36-32/Scripts/yapf.exe",
-            ]:
-                if os.path.exists(
-                        sublime.expand_variables(
-                            os.path.expanduser(common_location),
-                            sublime.active_window().extract_variables())):
-                    cmd = common_location
-                    settings = sublime.load_settings(PLUGIN_SETTINGS_FILE)
-                    settings.set("yapf_command", common_location)
-                    sublime.save_settings(PLUGIN_SETTINGS_FILE)
-                    break
+            cmd = which("yapf")
+
+        if not cmd:
+            cmd = which("yapf3")
+
+        if cmd and save_settings:
+            settings = sublime.load_settings(PLUGIN_SETTINGS_FILE)
+            settings.set("yapf_command", cmd)
+            sublime.save_settings(PLUGIN_SETTINGS_FILE)
 
         return cmd
 

--- a/PyYapf.py
+++ b/PyYapf.py
@@ -194,11 +194,9 @@ class Yapf:
 
         save_settings = not cmd
 
-        if not cmd:
-            cmd = which("yapf")
-
-        if not cmd:
-            cmd = which("yapf3")
+        for maybe_cmd in ['yapf', 'yapf3', 'yapf.exe', 'yapf3.exe']:
+            if not cmd:
+                cmd = which(maybe_cmd)
 
         if cmd and save_settings:
             settings = sublime.load_settings(PLUGIN_SETTINGS_FILE)

--- a/PyYapf.py
+++ b/PyYapf.py
@@ -182,23 +182,19 @@ class Yapf:
         """Find the yapf executable."""
         # default to what is in the settings file
         cmd = self.get_setting("yapf_command")
-        if not cmd:
-            # always show error in popup
-            msg = 'Yapf command not configured. Problem with settings?'
-            sublime.error_message(msg)
-            raise Exception(msg)
-
         cmd = os.path.expanduser(cmd)
         cmd = sublime.expand_variables(
             cmd,
             sublime.active_window().extract_variables())
 
-        if not os.path.exists(cmd):
+        if not cmd:
             # some common possibilities
             for common_location in [
                     "/usr/local/bin/yapf",  # most common
                     "/usr/bin/yapf3",  # Ubnt 18.04
                     "~/Library/Python/2.7/bin/yapf",  # OSx installed with --user
+                    "C:\\Python\\Scripts\\yapf.exe",  # Ugg.
+                    "~/AppData/Local/Programs/Python/Python36-32/Scripts/yapf.exe",
             ]:
                 if os.path.exists(
                         sublime.expand_variables(

--- a/PyYapf.sublime-settings
+++ b/PyYapf.sublime-settings
@@ -1,6 +1,6 @@
 {
       // full path and command to run yapf
-      "yapf_command": "/usr/local/bin/yapf",
+      "yapf_command": "",
 
       // reformat entire file if no text is selected
       "use_entire_file_if_no_selection": true,

--- a/backports/LICENSE
+++ b/backports/LICENSE
@@ -1,0 +1,27 @@
+This repo is Copyright (c) 2016 Min RK, and licensed under the MIT license.
+
+Since the source of `shutil.which` is a backport from a Python standard library module,
+the code itself is licensed under the Python Software Foundation (PSF) License.
+The backporting part (setup.py, etc.) are MIT.
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Min RK
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/backports/__init__.py
+++ b/backports/__init__.py
@@ -1,0 +1,4 @@
+# from https://github.com/minrk/backports.shutil_which
+
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/backports/shutil_which.py
+++ b/backports/shutil_which.py
@@ -1,0 +1,77 @@
+"""Backport of shutil.which from Python 3.5
+
+The function is included unmodified from Python stdlib 3.5.1,
+and is (C) Python
+"""
+
+import os
+import sys
+
+__version__ = '3.5.1'
+
+def backport_which(cmd, mode=os.F_OK | os.X_OK, path=None):
+    """Given a command, mode, and a PATH string, return the path which
+    conforms to the given mode on the PATH, or None if there is no such
+    file.
+
+    `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
+    of os.environ.get("PATH"), or can be overridden with a custom search
+    path.
+
+    """
+    # Check that a given file can be accessed with the correct mode.
+    # Additionally check that `file` is not a directory, as on Windows
+    # directories pass the os.access check.
+    def _access_check(fn, mode):
+        return (os.path.exists(fn) and os.access(fn, mode)
+                and not os.path.isdir(fn))
+
+    # If we're given a path with a directory part, look it up directly rather
+    # than referring to PATH directories. This includes checking relative to the
+    # current directory, e.g. ./script
+    if os.path.dirname(cmd):
+        if _access_check(cmd, mode):
+            return cmd
+        return None
+
+    if path is None:
+        path = os.environ.get("PATH", os.defpath)
+    if not path:
+        return None
+    path = path.split(os.pathsep)
+
+    if sys.platform == "win32":
+        # The current directory takes precedence on Windows.
+        if not os.curdir in path:
+            path.insert(0, os.curdir)
+
+        # PATHEXT is necessary to check on Windows.
+        pathext = os.environ.get("PATHEXT", "").split(os.pathsep)
+        # See if the given file matches any of the expected path extensions.
+        # This will allow us to short circuit when given "python.exe".
+        # If it does match, only test that one, otherwise we have to try
+        # others.
+        if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
+            files = [cmd]
+        else:
+            files = [cmd + ext for ext in pathext]
+    else:
+        # On other platforms you don't have things like PATHEXT to tell you
+        # what file suffixes are executable, so just pass on cmd as-is.
+        files = [cmd]
+
+    seen = set()
+    for dir in path:
+        normdir = os.path.normcase(dir)
+        if not normdir in seen:
+            seen.add(normdir)
+            for thefile in files:
+                name = os.path.join(dir, thefile)
+                if _access_check(name, mode):
+                    return name
+    return None
+
+try:
+    from shutil import which
+except ImportError:
+    which = backport_which


### PR DESCRIPTION
Simple approach -- check common yapf install locations.  What I don't know is what the common locations actually are.  It might be better to just bite the bullet and search $PATH but ugg.  Maybe call `which` (though I don't think `which` exists in windows).

PR to collect other paths yapf will land in before pushing a release.