### PR TITLE
WIP Initial support for "black" python formatter

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,10 +1,10 @@
 [
     {
         "caption": "PyYapf: Format Selection",
-        "command": "yapf_selection"
+        "command": "format_selection"
     },
     {
         "caption": "PyYapf: Format Document",
-        "command": "yapf_document"
+        "command": "format_document"
     }
 ]

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,3 +1,3 @@
 [
-  { "keys": ["ctrl+alt+f"], "command": "yapf_selection" }
+  { "keys": ["ctrl+alt+f"], "command": "format_selection" }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,3 +1,3 @@
 [
-  { "keys": ["ctrl+alt+f"], "command": "yapf_selection" }
+  { "keys": ["ctrl+alt+f"], "command": "format_selection" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,3 +1,3 @@
 [
-  { "keys": ["ctrl+alt+f"], "command": "yapf_selection" }
+  { "keys": ["ctrl+alt+f"], "command": "format_selection" }
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,10 +1,26 @@
 [
     {
         "caption": "PyYapf: Format Selection",
-        "command": "yapf_selection"
+        "command": "format_selection"
     },
     {
         "caption": "PyYapf: Format Document",
+        "command": "format_document"
+    },
+    {
+        "caption": "PyYapf: Yapf Format Selection",
+        "command": "yapf_selection"
+    },
+    {
+        "caption": "PyYapf: Yapf Format Document",
         "command": "yapf_document"
-    }
+    },
+    {
+        "caption": "PyYapf: Black Format Selection",
+        "command": "black_selection"
+    },
+    {
+        "caption": "PyYapf: Black Format Document",
+        "command": "black_document"
+    },
 ]

--- a/PyYapf.sublime-settings
+++ b/PyYapf.sublime-settings
@@ -1,4 +1,10 @@
 {
+      //Can be "yapf" or "black"
+      "formatter": "yapf",
+
+      // full path and command to run black
+      "black_command": "",
+
       // full path and command to run yapf
       "yapf_command": "",
 


### PR DESCRIPTION
Work in progress, I want to make it easy to use either yapf or black.  This is a quick proof of concept, the golden path works on my local but it needs some testing.  I'm thinking to improve the quality of this plugin I'll write up a test checklist.  Automating testing is hard, though adding doc tests isn't a totally crazy idea.

Anyway.. TLDR; I'm adding support for 'black' which kinds makes the plugin badly named.  Oh well.