### PR TITLE
config to ignore yapf-on-save based on wildcards

### DIFF
--- a/PyYapf.sublime-settings
+++ b/PyYapf.sublime-settings
@@ -8,6 +8,9 @@
       // run yapf before saving document
       "on_save": false,
 
+      // ignore files matching glob(s)
+      "onsave_ignore_fn_glob": ["*.pyx", ],
+
       // report errors in popup dialog (in addition to status bar)
       "popup_errors": false,
 


### PR DESCRIPTION
will highlight the non-cosmetic portion

this adds a config setting of filename globs, any file matching a glob will not automatically trigger yapf when the file is saved.